### PR TITLE
Fix spelling error in notices

### DIFF
--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -100,7 +100,7 @@ function admin_notice() {
 		return;
 	}
 
-	printf( '<div class="%s"><p>%s</p></div>', 'notice notice-error is-dissmissible', $error );
+	printf( '<div class="%s"><p>%s</p></div>', 'notice notice-error is-dismissible', $error );
 }
 
 /**


### PR DESCRIPTION
There was a super-minor spelling error in the notices class; figured I'd fix it real quick.