### PR TITLE
Document Scope Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ add_action( 'init', function() {
 } );
 ```
 
+Scope of Setting a Flag
+==========
+
+A flag can be set at either the `user` or `site` scope, which determines how a flag is controlled. A `user`-scoped flag can be turned on or off by each user for that user only on a site, whereas a `site`-scoped flag is turned on or off for every user and is controlled in the site settings. 
+
 Credits
 =======
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ add_action( 'init', function() {
         'available' => function() {
             return current_user_can( 'manage_options' );
         },
+        // At what level the flag can be set. One of `user` or `site`
+        'scope' => 'user',
         // Default flag status
         'active' => true,
         // Is the flag controllable by users ?

--- a/inc/class-flag.php
+++ b/inc/class-flag.php
@@ -70,9 +70,10 @@ class Flag {
 	 * @param string $title   Proper display name for the flag.
 	 * @param array  $options Options available to the flag.
 	 *     @type callback $available Is the flag exposed to users?
-	 *     @type callback $active    Default flag status
-	 *     @type callback $optin     Is the flag controllable by users?
-	 *     @type callback $icon      Custom icon? (dashicon-compatible)
+	 *     @type string   $scope     At what level the flag can be set. One of `user` or `site`.
+	 *     @type bool     $active    Default flag status
+	 *     @type bool     $optin     Is the flag controllable by users?
+	 *     @type string   $icon      Custom icon? (dashicon-compatible)
 	 *     Optional extra parameters.
 	 */
 	public function __construct( string $id, string $title, array $options = [] ) {


### PR DESCRIPTION
Documents the various options for `scope` and how they're set. Also fixes the option `@type` types which I mistakenly copied and pasted down the list.