### PR TITLE
Fix sanitization bug which prevented flags from being disabled through the admin bar

### DIFF
--- a/inc/class-flag.php
+++ b/inc/class-flag.php
@@ -129,9 +129,9 @@ class Flag {
 	}
 
 	/**
-	 * Get the meta key used for our flag.
+	 * Get the underlying storage object (meta or option) key used for our flag.
 	 */
-	public function get_meta_key() : string {
+	public function get_storage_key() : string {
 		return sprintf( '_wp_flag_%s', $this->id );
 	}
 

--- a/inc/site-metabox.php
+++ b/inc/site-metabox.php
@@ -86,11 +86,11 @@ function render() {
 /**
  * Convert values from on/off to `active`/`inactive`.
  *
- * @param string $value Value to check against.
+ * @param string $value Value to check against, expected to be boolean or "active"|"inactive".
  * @return string Value to save.
  */
 function sanitize_value( $value ) : string {
-	return $value
+	return ( $value && $value !== 'inactive' )
 		? 'active'
 		: 'inactive';
 }

--- a/inc/site-metabox.php
+++ b/inc/site-metabox.php
@@ -41,7 +41,7 @@ function register_settings() {
 	foreach ( get_all_site_flags() as $flag ) {
 		register_setting(
 			'general',
-			$flag->get_meta_key(),
+			$flag->get_storage_key(),
 			[
 				'sanitize_callback' => __NAMESPACE__ . '\\sanitize_value',
 				'type' => 'string',
@@ -57,7 +57,7 @@ function render() {
 	$flags  = get_all_site_flags();
 	$values = call_user_func_array( 'array_merge', array_map( function ( $flag ) {
 		/* @var \HumanMade\Flags\Flag $flag */
-		return [ $flag->id => get_option( $flag->get_meta_key(), true, '' ) === 'active' ];
+		return [ $flag->id => get_option( $flag->get_storage_key(), true, '' ) === 'active' ];
 	}, $flags ) );
 	?>
 	<table class="form-table">
@@ -67,7 +67,7 @@ function render() {
 					<label for="wp-flags-<?php echo esc_attr( $flag->id ); ?>">
 						<input
 								type="checkbox"
-								name="<?php echo esc_attr( $flag->get_meta_key() ); ?>"
+								name="<?php echo esc_attr( $flag->get_storage_key() ); ?>"
 								id="wp-flags-<?php echo esc_attr( $flag->id ); ?>"
 								value="1"
 							<?php checked( true, $values[ $flag->id ] ?? false ); ?>

--- a/inc/site.php
+++ b/inc/site.php
@@ -58,5 +58,5 @@ function handle( Flag $flag ) {
  * @return bool|int
  */
 function save( bool $value, Flag $flag ) {
-	return update_option( $flag->get_meta_key(), $value ? 'active' : 'inactive' );
+	return update_option( $flag->get_meta_key(), $value );
 }

--- a/inc/site.php
+++ b/inc/site.php
@@ -40,7 +40,7 @@ function handle( Flag $flag ) {
 	}
 
 	// Get site preference, if any, to set current status of the flag.
-	$value = get_option( $flag->get_meta_key(), true, '' );
+	$value = get_option( $flag->get_storage_key(), true, '' );
 	if ( $value ) {
 		$flag->set( 'active', $value === 'active' );
 	}
@@ -58,5 +58,5 @@ function handle( Flag $flag ) {
  * @return bool|int
  */
 function save( bool $value, Flag $flag ) {
-	return update_option( $flag->get_meta_key(), $value );
+	return update_option( $flag->get_storage_key(), $value );
 }

--- a/inc/user-metabox.php
+++ b/inc/user-metabox.php
@@ -34,7 +34,7 @@ function render( \WP_User $user ) {
 	);
 	$values = call_user_func_array( 'array_merge', array_map( function ( $flag ) use ( $user ) {
 		/* @var \HumanMade\Flags\Flag $flag */
-		return [ $flag->id => get_user_meta( $user->ID, $flag->get_meta_key(), true ) === 'active' ];
+		return [ $flag->id => get_user_meta( $user->ID, $flag->get_storage_key(), true ) === 'active' ];
 	}, $flags ) );
 	?>
 	<table class="form-table">
@@ -84,7 +84,7 @@ function save( int $user_id ) {
 	$values = filter_input( INPUT_POST, 'wp-flags', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
 	foreach ( $flags as $flag ) {
 		$value = isset( $values[ $flag->id ] ) ? 'active' : 'inactive';
-		update_user_meta( $user_id, $flag->get_meta_key(), $value );
+		update_user_meta( $user_id, $flag->get_storage_key(), $value );
 	}
 
 	return true;

--- a/inc/user.php
+++ b/inc/user.php
@@ -40,7 +40,7 @@ function handle( Flag $flag ) {
 	}
 
 	// Get user preference, if any, to set current status of the flag.
-	$value = get_user_meta( get_current_user_id(), $flag->get_meta_key(), true );
+	$value = get_user_meta( get_current_user_id(), $flag->get_storage_key(), true );
 	if ( $value ) {
 		$flag->set( 'active', $value === 'active' );
 	}
@@ -58,5 +58,5 @@ function handle( Flag $flag ) {
  * @return bool|int
  */
 function save( bool $value, Flag $flag ) {
-	return update_user_meta( get_current_user_id(), $flag->get_meta_key(), $value ? 'active' : 'inactive' );
+	return update_user_meta( get_current_user_id(), $flag->get_storage_key(), $value ? 'active' : 'inactive' );
 }


### PR DESCRIPTION
#6 introduced a sanitization function for the settings field used to hold a site-wide option which converts boolean true/false values to "active" or "inactive". 

Because of this, we need to make sure to update flags as a boolean, to avoid "double-sanitizing" errors: trying to set a post to "inactive" would be type-juggled to "true", and that would be converted to "active" by the sanitize callback.

Fixes #12.

Also renames the method `Flag::get_meta_key` to `Flag::get_storage_key` to avoid confusion, since not all flags use meta fields.