### PR TITLE
Hotfix: fix urlencoding of the Ajax endpoint return URI

### DIFF
--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -88,7 +88,7 @@ function get_toggle_url( Flag $flag ) : string {
 			'flag'     => $flag->id,
 			'status'   => (int) ! $flag->active,
 			'nonce'    => wp_create_nonce( 'wp_flags' ),
-			'redirect' => $_SERVER['REQUEST_URI'],
+			'redirect' => rawurlencode( $_SERVER['REQUEST_URI'] ),
 		],
 		admin_url( 'admin-ajax.php' )
 	);


### PR DESCRIPTION
When trying to toggle a feature flag from a page containing a query string, the Ajax endpoint generated is malformed and doesn't hit the handler function properly. This change fixes that issue by properly url-encoding this parameter so that the "redirect" query string argument is preserved.

**Testing:**

Try toggling a feature flag from an edit post page. The Ajax URL will look something like this:

https://site.dev/wp-admin/admin-ajax.php?action=wp_flag_ajax_trigger&flag=flag-name&status=1&nonce=37d46e253b&redirect=/wp-admin/post.php?post=315646&action=edit

Note that there are two "action" parameters in the query string, so the second one "edit" is used as the Ajax action to trigger, instead of the correct "wp_flag_ajax_trigger". As a result, the ajax handler is never triggered.

After this PR, that redirect parameter is url-encoded so the Ajax URL looks like

https://site.dev/wp-admin/admin-ajax.php?action=wp_flag_ajax_trigger&flag=flag-name&status=1&nonce=37d46e253b&redirect=%2Fwp-admin%2Fpost.php%3Fpost%3D315646%26action%3Dedit
