### PR TITLE
Fix PHP8 error

### DIFF
--- a/inc/site-metabox.php
+++ b/inc/site-metabox.php
@@ -55,10 +55,11 @@ function register_settings() {
  */
 function render() {
 	$flags  = get_all_site_flags();
-	$values = array_values( call_user_func_array( 'array_merge', array_map( function ( $flag ) {
+	$values = array();
+	foreach( $flags as $flag ) {
 		/* @var \HumanMade\Flags\Flag $flag */
-		return [ $flag->id => get_option( $flag->get_storage_key(), true, '' ) === 'active' ];
-	}, $flags ) ) );
+		$values[ $flag->id ] = get_option( $flag->get_storage_key(), true, '' ) === 'active';
+	}
 	?>
 	<table class="form-table">
 		<tr>

--- a/inc/site-metabox.php
+++ b/inc/site-metabox.php
@@ -55,10 +55,10 @@ function register_settings() {
  */
 function render() {
 	$flags  = get_all_site_flags();
-	$values = call_user_func_array( 'array_merge', array_map( function ( $flag ) {
+	$values = array_values( call_user_func_array( 'array_merge', array_map( function ( $flag ) {
 		/* @var \HumanMade\Flags\Flag $flag */
 		return [ $flag->id => get_option( $flag->get_storage_key(), true, '' ) === 'active' ];
-	}, $flags ) );
+	}, $flags ) ) );
 	?>
 	<table class="form-table">
 		<tr>


### PR DESCRIPTION
PHP8 is throwing this error when I view the `options-general.php` settings page:

```php
Fatal error: Uncaught Error: array_merge() does not accept unknown named parameters
in /usr/src/plugins-mgr/plugins/wp-flags/inc/site-metabox.php on line 59

Call stack:
array_merge()
call_user_func_array()
/usr/src/plugins-mgr/plugins/wp-flags/inc/site-metabox.php:59
HumanMade\F\S\render()
wp-admin/includes/template.php:1737
do_settings_fields()
wp-admin/includes/template.php:1695
do_settings_sections()
wp-admin/options-general.php:401
```