### PR TITLE
Fix PHP 8.2 named-parameter error in user metabox

### DIFF
--- a/inc/user-metabox.php
+++ b/inc/user-metabox.php
@@ -32,10 +32,10 @@ function render( \WP_User $user ) {
 			'scope' => 'user',
 		]
 	);
-	$values = call_user_func_array( 'array_merge', array_map( function ( $flag ) use ( $user ) {
-		/* @var \HumanMade\Flags\Flag $flag */
-		return [ $flag->id => get_user_meta( $user->ID, $flag->get_storage_key(), true ) === 'active' ];
-	}, $flags ) );
+	$values = [];
+	foreach ( $flags as $flag ) {
+		$values[ $flag->id ] = get_user_meta( $user->ID, $flag->get_storage_key(), true ) === 'active';
+	}
 	?>
 	<table class="form-table">
 		<tr>


### PR DESCRIPTION
## What changed
The user-flags metabox built its `id => bool` map by passing `array_merge` to `call_user_func_array` along with an array of `[id => bool]` pairs. I replaced that with a simple `foreach` that builds the same map.

## Why
On PHP 8.2 the old line throws an error. PHP 8.2 added named arguments, and when `call_user_func_array` is given an array with string keys, PHP now treats those keys as named-argument names. `array_merge` doesn't accept named arguments, so it errors out as soon as the metabox renders.

The new loop does the same job — same input, same output — but doesn't go through `call_user_func_array`, so PHP 8.2 has no problem with it.

## Test plan
- [x] Visit a user's profile in wp-admin on PHP 8.2 with at least one user-scoped flag registered.
- [x] Confirm the Flags metabox renders, the checkboxes show the right state, and saving toggles them.
- [x] No PHP error/warning in the log on render or save.

Found while running standard-chartered-nr on PHP 8.2 — we're carrying this as a downstream patch (`composer.patches.json`) until this lands and a tag is cut.